### PR TITLE
feat!: scraper revamp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@
 # Uncomment and fill these in if you want to use Supabase integration
 # SUPABASE_URL=https://your-project.supabase.co
 # SUPABASE_ANON_KEY=your-anon-key-here
+# ENABLE_SUPABASE=false

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example Environment Configuration
+# Copy this file to .env and fill in your values
+
+# Supabase Configuration (Optional)
+# Uncomment and fill these in if you want to use Supabase integration
+# SUPABASE_URL=https://your-project.supabase.co
+# SUPABASE_ANON_KEY=your-anon-key-here

--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,5 @@
 # Supabase Configuration (Optional)
 # Uncomment and fill these in if you want to use Supabase integration
 # SUPABASE_URL=https://your-project.supabase.co
-# SUPABASE_ANON_KEY=your-anon-key-here
+# SUPABASE_KEY=your-service-key-here
 # ENABLE_SUPABASE=false

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dist
 .pnp.*
 
 data
+performance-test-results

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,0 +1,122 @@
+# 🚀 Quick Start Guide
+
+Get up and running with the UT Dining Scraper in 5 minutes!
+
+## ⚡ One-Command Setup
+
+```bash
+# Install dependencies and build
+pnpm install && pnpm build
+
+# Run the scraper
+pnpm start
+```
+
+## 🎯 Most Common Use Cases
+
+### 1. Basic Menu Scraping
+
+```bash
+node dist/index.js
+```
+
+**Output**: JSON file in `data/` folder with all menu data
+
+### 2. Find Optimal Performance Settings
+
+```bash
+./run-performance-test.sh
+```
+
+**Output**: Recommended concurrency settings for your network
+
+## 📊 Understanding Your Results
+
+### JSON Output Structure
+
+```json
+{
+  "locationName": "J2 Dining",
+  "menus": [
+    {
+      "type": "Lunch",
+      "menuCategories": [
+        {
+          "categoryName": "Main Dishes",
+          "foods": [
+            {
+              "name": "Grilled Chicken",
+              "allergens": { "milk": false, "wheat": true },
+              "nutrition": {
+                "calories": 250,
+                "protein": "25g",
+                "totalFat": "8g"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Performance Test Results
+
+- **Best Score** = Highest throughput with >95% success rate
+- **Apply Settings** = Update `NUTRITION_CONCURRENCY` and `MENU_CONCURRENCY` in `src/index.ts`
+
+## 🔧 Quick Configuration
+
+### Speed vs Reliability
+
+```typescript
+// Conservative (slower, more reliable)
+const NUTRITION_CONCURRENCY = 30;
+const MENU_CONCURRENCY = 6;
+
+// Aggressive (faster, might have more errors)
+const NUTRITION_CONCURRENCY = 80;
+const MENU_CONCURRENCY = 10;
+```
+
+### Target Specific Locations
+
+```typescript
+const LINKS = [
+  "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?locationName=J2+Dining",
+  // Comment out locations you don't need
+];
+```
+
+## 🆘 Quick Fixes
+
+### "Permission denied" on run-performance-test.sh
+
+```bash
+chmod +x run-performance-test.sh
+```
+
+### High error rate
+
+```typescript
+// Reduce these values in src/index.ts
+const NUTRITION_CONCURRENCY = 20; // Lower this
+const MENU_CONCURRENCY = 5; // Lower this
+```
+
+### Slow performance
+
+```bash
+# Run performance test to find optimal settings
+./run-performance-test.sh
+```
+
+## 📱 Next Steps
+
+1. **Run your first scrape** with default settings
+2. **Run performance test** to optimize for your network
+3. **Apply optimal settings** from performance test results
+4. **Set up automated runs** if needed
+
+That's it! You're ready to scrape UT dining data efficiently! 🎉

--- a/README.md
+++ b/README.md
@@ -1,0 +1,309 @@
+# UT Dining Scraper
+
+A high-performance web scraper for University of Texas dining hall menus, built with TypeScript, Cheerio, and Supabase integration. This tool scrapes menu data, nutrition information, and allergen details from the UT dining system.
+
+## 🚀 Features
+
+- **Fast Scraping**: Uses Cheerio and fetch for lightweight, efficient scraping
+- **Parallel Processing**: Configurable concurrency for optimal performance
+- **Nutrition Data**: Extracts detailed nutrition facts for each menu item
+- **Allergen Information**: Identifies allergens and dietary restrictions
+- **Supabase Integration**: Direct database insertion capabilities
+- **Performance Testing**: Built-in performance testing suite
+- **Error Handling**: Robust retry mechanisms and error recovery
+- **TypeScript**: Full type safety and IntelliSense support
+
+## 📋 Prerequisites
+
+- **Node.js** (v16 or higher)
+- **pnpm** (package manager)
+- **TypeScript** (installed globally or via pnpm)
+
+## 🛠️ Installation
+
+1. **Clone the repository**
+
+   ```bash
+   git clone <repository-url>
+   cd ut-dining-scraper
+   ```
+
+2. **Install dependencies**
+
+   ```bash
+   pnpm install
+   ```
+
+3. **Set up environment variables** (optional, for Supabase)
+
+   ```bash
+   cp .env.example .env
+   # Edit .env with your Supabase credentials
+   ```
+
+4. **Build the project**
+   ```bash
+   pnpm build
+   ```
+
+## 🏃‍♂️ Quick Start
+
+### Basic Usage
+
+1. **Run the scraper**
+
+   ```bash
+   pnpm start
+   # or
+   node dist/index.js
+   ```
+
+2. **Output**
+   - JSON file saved to `data/` directory
+   - Console output with progress and statistics
+   - Optional Supabase insertion (if configured)
+
+### Example Output
+
+```
+🚀 Starting menu scraping with Cheerio...
+📍 Found 7 dining locations to process
+🏢 Processing J2 Dining (3 menus found)
+  📋 Lunch menu: 74 food items across 12 categories
+  ✅ Lunch: 74/74 items with nutrition data
+📊 Scraped 7 locations, 3 menus, 177 food items
+💾 Data saved to data/ut_menus_2025-06-21T16-42-58-936Z.json
+⏱️ Total scraping time: 4.32 seconds
+```
+
+## ⚙️ Configuration
+
+### Concurrency Settings
+
+Located in `src/index.ts`:
+
+```typescript
+const NUTRITION_CONCURRENCY = 50; // Parallel nutrition requests
+const MENU_CONCURRENCY = 7; // Parallel menu page requests
+```
+
+### Dining Locations
+
+Modify the `LINKS` array in `src/index.ts` to add/remove locations:
+
+```typescript
+const LINKS = [
+  "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?locationName=J2+Dining",
+  // Add more locations here
+];
+```
+
+### Supabase Integration
+
+1. **Enable Supabase** by setting `ENABLE_SUPABASE` to `true` in `src/index.ts`:
+
+   ```typescript
+   const ENABLE_SUPABASE = true; // Set to true to enable Supabase insertion
+   ```
+
+2. **Configure credentials** in `.env`:
+   ```env
+   SUPABASE_URL=your_supabase_url
+   SUPABASE_ANON_KEY=your_anon_key
+   ```
+
+## 📊 Performance Testing
+
+The project includes a comprehensive performance testing suite to find optimal concurrency settings.
+
+### 🧪 Running Performance Tests
+
+#### Option 1: Using the Script (Recommended)
+
+```bash
+chmod +x run-performance-test.sh
+./run-performance-test.sh
+```
+
+#### Option 2: Manual Commands
+
+```bash
+pnpm build
+node dist/performance-test.js
+```
+
+### 📈 What the Performance Test Does
+
+The performance test systematically evaluates different concurrency configurations:
+
+| Test Config  | Nutrition Concurrency | Menu Concurrency | Purpose          |
+| ------------ | --------------------- | ---------------- | ---------------- |
+| Conservative | 20                    | 5                | Safe baseline    |
+| Low          | 30                    | 6                | Light load       |
+| Baseline     | 40                    | 7                | Current default  |
+| Moderate     | 50                    | 7                | Recommended      |
+| Aggressive   | 60-70                 | 8                | High performance |
+| Maximum      | 80-100                | 9-10             | Stress test      |
+
+### 📊 Performance Metrics
+
+Each test measures:
+
+- **⏱️ Duration**: Total scraping time
+- **🔢 Items/Second**: Processing throughput
+- **✅ Success Rate**: Percentage of successful nutrition fetches
+- **❌ Error Count**: Number of failed requests
+- **🏆 Composite Score**: Overall performance rating
+
+### 📋 Sample Performance Test Output
+
+```
+🧪 Testing: Nutrition=50, Menu=7
+   ⏱️  Duration: 4.12s
+   📊 Items: 177 (43.0/s)
+   ✅ Success Rate: 98.3%
+   ❌ Errors: 3
+
+📈 PERFORMANCE TEST RESULTS
+═══════════════════════════════════════════════════════════════════════════════
+Nutrition | Menu | Duration | Items/s | Success% | Errors | Score
+───────────────────────────────────────────────────────────────────────────────
+       20 |    5 |     8.45s |    20.9 |    100.0 |      0 | 20.90
+       50 |    7 |     4.12s |    43.0 |     98.3 |      3 | 41.27
+       70 |    8 |     3.21s |    55.1 |     96.6 |      6 | 51.89
+
+🏆 OPTIMAL CONFIGURATION:
+   Nutrition Concurrency: 70
+   Menu Concurrency: 8
+   Performance: 55.1 items/second
+   Success Rate: 96.6%
+   Duration: 3.21 seconds
+```
+
+### 📁 Performance Test Results
+
+Results are automatically saved to:
+
+- **Console**: Real-time progress and summary
+- **JSON File**: `performance-test-results/performance_test_[timestamp].json`
+
+### 🎯 Interpreting Results
+
+**Look for:**
+
+- ✅ Success rate > 95%
+- ⚡ High items/second ratio
+- 🎯 Low error count
+- 🏆 High composite score
+
+**Warning signs:**
+
+- ❌ Success rate < 90%
+- 🐌 Decreasing items/second despite higher concurrency
+- 💥 High error count
+
+### ⚡ Applying Optimal Settings
+
+After running performance tests, update your configuration in `src/index.ts`:
+
+```typescript
+// Use the optimal values from your performance test results
+const NUTRITION_CONCURRENCY = 70; // Example optimal value
+const MENU_CONCURRENCY = 8; // Example optimal value
+```
+
+## 📁 Project Structure
+
+```
+ut-dining-scraper/
+├── src/
+│   ├── index.ts              # Main scraper application
+│   ├── performance-test.ts   # Performance testing suite
+│   ├── supabase.ts          # Supabase configuration
+│   └── types/               # TypeScript type definitions
+├── data/                    # Scraped menu data (JSON files)
+├── performance-test-results/ # Performance test results
+├── dist/                    # Compiled JavaScript (generated)
+├── package.json
+├── tsconfig.json
+└── run-performance-test.sh  # Performance test runner script
+```
+
+## 🚨 Troubleshooting
+
+### Common Issues
+
+**Slow Performance**
+
+- Run performance tests to find optimal concurrency
+- Check network connection
+- Verify server isn't rate-limiting
+
+**High Error Rates**
+
+- Reduce concurrency values
+- Check if dining sites are accessible
+- Verify network stability
+
+**TypeScript Errors**
+
+```bash
+# Clean build
+rm -rf dist/
+pnpm build
+```
+
+**Permission Errors**
+
+```bash
+chmod +x run-performance-test.sh
+```
+
+## 📜 Available Scripts
+
+```bash
+# Build the project
+pnpm build
+
+# Run the main scraper
+pnpm start
+
+# Run performance tests
+pnpm run performance-test:script
+
+# Development mode with watch
+pnpm dev
+
+# Clean build artifacts
+pnpm clean
+
+# One-command setup
+pnpm quick-start
+```
+
+📋 **For a complete commands reference, see [COMMANDS.md](COMMANDS.md)**
+
+## 📚 Documentation
+
+- **[README.md](README.md)** - Main documentation (you are here)
+- **[QUICK_START.md](QUICK_START.md)** - Get running in 5 minutes
+
+## 🤝 Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Run performance tests to ensure no regression
+5. Submit a pull request
+
+## 📄 License
+
+This project is licensed under the ISC License.
+
+## 🙋‍♂️ Support
+
+For issues and questions:
+
+1. Check the troubleshooting section
+2. Run performance tests to identify configuration issues
+3. Create an issue with relevant logs and configuration details

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ const LINKS = [
 
 ### Supabase Integration
 
-1. **Enable Supabase** by setting `ENABLE_SUPABASE` to `true` in `src/index.ts`:
+1. **Enable Supabase** by setting `ENABLE_SUPABASE` in your `.env` file:
 
-   ```typescript
-   const ENABLE_SUPABASE = true; // Set to true to enable Supabase insertion
+   ```env
+   ENABLE_SUPABASE=true # Set to true to enable Supabase insertion, or false to disable
    ```
 
 2. **Configure credentials** in `.env`:

--- a/package.json
+++ b/package.json
@@ -1,15 +1,27 @@
 {
-  "name": "ut-dining-hall-server",
+  "name": "ut-dining-scraper",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "description": "High-performance web scraper for University of Texas at Austin dining hall menus with nutrition data and allergen information",
+  "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "watch": "pnpm tsc -w",
-    "build": "pnpm tsc",
-    "start": "npx puppeteer browsers install chrome && pnpm build && node dist/index.js"
+    "build": "tsc",
+    "start": "pnpm run build && node dist/index.js",
+    "dev": "tsc --watch",
+    "performance-test": "pnpm run build && node dist/performance-test.js",
+    "performance-test:script": "./run-performance-test.sh",
+    "clean": "rm -rf dist/",
+    "scrape": "pnpm run start",
+    "quick-start": "pnpm install && pnpm run build && pnpm run start"
   },
-  "keywords": [],
+  "keywords": [
+    "web-scraping",
+    "university-texas",
+    "dining-halls",
+    "nutrition-data",
+    "typescript",
+    "cheerio",
+    "performance-testing"
+  ],
   "author": "",
   "license": "ISC",
   "devDependencies": {
@@ -17,8 +29,8 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.48.1",
+    "cheerio": "^1.1.0",
     "dotenv": "^16.4.7",
-    "p-limit": "^6.2.0",
-    "puppeteer": "^24.1.1"
+    "p-limit": "^6.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,34 +11,21 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.48.1
         version: 2.48.1
+      cheerio:
+        specifier: ^1.1.0
+        version: 1.1.0
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
       p-limit:
         specifier: ^6.2.0
         version: 6.2.0
-      puppeteer:
-        specifier: ^24.1.1
-        version: 24.1.1(typescript@5.7.3)
     devDependencies:
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
 
 packages:
-
-  '@babel/code-frame@7.26.2':
-    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.25.9':
-    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@puppeteer/browsers@2.7.0':
-    resolution: {integrity: sha512-bO61XnTuopsz9kvtfqhVbH6LTM1koxK0IlBR+yuVrM2LB7mk8+5o1w18l5zqd5cs8xlf+ntgambqRqGifMDjog==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   '@supabase/auth-js@2.67.3':
     resolution: {integrity: sha512-NJDaW8yXs49xMvWVOkSIr8j46jf+tYHV0wHhrwOaLLMZSFO4g6kKAf+MfzQ2RaD06OCUkUHIzctLAxjTgEVpzw==}
@@ -62,9 +49,6 @@ packages:
   '@supabase/supabase-js@2.48.1':
     resolution: {integrity: sha512-VMD+CYk/KxfwGbI4fqwSUVA7CLr1izXpqfFerhnYPSi6LEKD8GoR4kuO5Cc8a+N43LnfSQwLJu4kVm2e4etEmA==}
 
-  '@tootallnate/quickjs-emscripten@0.23.0':
-    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
-
   '@types/node@22.12.0':
     resolution: {integrity: sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==}
 
@@ -74,375 +58,105 @@ packages:
   '@types/ws@8.5.14':
     resolution: {integrity: sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==}
 
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  agent-base@7.1.3:
-    resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
-    engines: {node: '>= 14'}
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
 
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
+  cheerio@1.1.0:
+    resolution: {integrity: sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==}
+    engines: {node: '>=18.17'}
 
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
+  css-select@5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
 
-  argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+  css-what@6.1.0:
+    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+    engines: {node: '>= 6'}
 
-  ast-types@0.13.4:
-    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
-    engines: {node: '>=4'}
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
-  b4a@1.6.7:
-    resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
 
-  bare-events@2.5.4:
-    resolution: {integrity: sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==}
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
 
-  bare-fs@4.0.1:
-    resolution: {integrity: sha512-ilQs4fm/l9eMfWY2dY0WCIUplSUp7U0CT1vrqMg1MUdeZl4fypu5UP0XcDBK5WBQPJAKP1b7XEodISmekH/CEg==}
-    engines: {bare: '>=1.7.0'}
-
-  bare-os@3.4.0:
-    resolution: {integrity: sha512-9Ous7UlnKbe3fMi7Y+qh0DwAup6A1JkYgPnjvMDNOlmnxNRQvQ/7Nst+OnUQKzk0iAT0m9BisbDVp9gCv8+ETA==}
-    engines: {bare: '>=1.6.0'}
-
-  bare-path@3.0.0:
-    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
-
-  bare-stream@2.6.4:
-    resolution: {integrity: sha512-G6i3A74FjNq4nVrrSTUz5h3vgXzBJnjmWAVlBWaZETkgu+LgKd7AiyOml3EDJY1AHlIbBHKDXE+TUT53Ff8OaA==}
-    peerDependencies:
-      bare-buffer: '*'
-      bare-events: '*'
-    peerDependenciesMeta:
-      bare-buffer:
-        optional: true
-      bare-events:
-        optional: true
-
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  basic-ftp@5.0.5:
-    resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
-    engines: {node: '>=10.0.0'}
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
-  callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
-
-  chromium-bidi@1.1.0:
-    resolution: {integrity: sha512-HislCEczCuamWm3+55Lig9XKmMF13K+BGKum9rwtDAzgUAHT4h5jNwhDmD4U20VoVUG8ujnv9UZ89qiIf5uF8w==}
-    peerDependencies:
-      devtools-protocol: '*'
-
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
-
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  cosmiconfig@9.0.0:
-    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=4.9.5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  data-uri-to-buffer@6.0.2:
-    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
-    engines: {node: '>= 14'}
-
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  degenerator@5.0.1:
-    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
-    engines: {node: '>= 14'}
-
-  devtools-protocol@0.0.1380148:
-    resolution: {integrity: sha512-1CJABgqLxbYxVI+uJY/UDUHJtJ0KZTSjNYJYKqd9FRoXT33WDakDHNxRapMEgzeJ/C3rcs01+avshMnPmKQbvA==}
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
 
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
 
-  end-of-stream@1.4.4:
-    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
-  env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
-  error-ex@1.3.2:
-    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+  htmlparser2@10.0.0:
+    resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
 
-  escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
-
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
-
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
-
-  esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
-  fast-fifo@1.3.2:
-    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
-
-  get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
-  get-uri@6.0.4:
-    resolution: {integrity: sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==}
-    engines: {node: '>= 14'}
-
-  http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
-
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
-
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
-  import-fresh@3.3.0:
-    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
-    engines: {node: '>=6'}
-
-  ip-address@9.0.5:
-    resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
-    engines: {node: '>= 12'}
-
-  is-arrayish@0.2.1:
-    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
-
-  js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
-    hasBin: true
-
-  jsbn@1.1.0:
-    resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
-
-  json-parse-even-better-errors@2.3.1:
-    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-
-  lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-
-  lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
-
-  mitt@3.0.1:
-    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
-
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  netmask@2.0.2:
-    resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
-    engines: {node: '>= 0.4.0'}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   p-limit@6.2.0:
     resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
     engines: {node: '>=18'}
 
-  pac-proxy-agent@7.1.0:
-    resolution: {integrity: sha512-Z5FnLVVZSnX7WjBg0mhDtydeRZ1xMcATZThjySQUHqr+0ksP8kqaw23fNKkaaN/Z8gwLUs/W7xdl0I75eP2Xyw==}
-    engines: {node: '>= 14'}
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
 
-  pac-resolver@7.0.1:
-    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
-    engines: {node: '>= 14'}
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
 
-  parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
-  parse-json@5.2.0:
-    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
-    engines: {node: '>=8'}
-
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
-  picocolors@1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-
-  progress@2.0.3:
-    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
-    engines: {node: '>=0.4.0'}
-
-  proxy-agent@6.5.0:
-    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
-    engines: {node: '>= 14'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
-  pump@3.0.2:
-    resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
-
-  puppeteer-core@24.1.1:
-    resolution: {integrity: sha512-7FF3gq6bpIsbq3I8mfbodXh3DCzXagoz3l2eGv1cXooYU4g0P4mcHQVHuBD4iSZPXNg8WjzlP5kmRwK9UvwF0A==}
-    engines: {node: '>=18'}
-
-  puppeteer@24.1.1:
-    resolution: {integrity: sha512-fuhceZ5HZuDXVuaMIRxUuDHfCJLmK0pXh8FlzVQ0/+OApStevxZhU5kAVeYFOEqeCF5OoAyZjcWbdQK27xW/9A==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-
-  resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
-
-  semver@7.7.0:
-    resolution: {integrity: sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
-
-  socks@2.8.3:
-    resolution: {integrity: sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-
-  sprintf-js@1.1.3:
-    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
-
-  streamx@2.22.0:
-    resolution: {integrity: sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==}
-
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
-
-  tar-fs@3.0.8:
-    resolution: {integrity: sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==}
-
-  tar-stream@3.1.7:
-    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
-
-  text-decoder@1.2.3:
-    resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
-
-  through@2.3.8:
-    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  typed-query-selector@2.12.0:
-    resolution: {integrity: sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==}
 
   typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  unbzip2-stream@1.4.3:
-    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
-
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
+  undici@7.10.0:
+    resolution: {integrity: sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==}
+    engines: {node: '>=20.18.1'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
@@ -456,51 +170,11 @@ packages:
       utf-8-validate:
         optional: true
 
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-
-  yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
-
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
-
   yocto-queue@1.1.1:
     resolution: {integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==}
     engines: {node: '>=12.20'}
 
-  zod@3.24.1:
-    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
-
 snapshots:
-
-  '@babel/code-frame@7.26.2':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
-  '@babel/helper-validator-identifier@7.25.9': {}
-
-  '@puppeteer/browsers@2.7.0':
-    dependencies:
-      debug: 4.4.0
-      extract-zip: 2.0.1
-      progress: 2.0.3
-      proxy-agent: 6.5.0
-      semver: 7.7.0
-      tar-fs: 3.0.8
-      unbzip2-stream: 1.4.3
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bare-buffer
-      - supports-color
 
   '@supabase/auth-js@2.67.3':
     dependencies:
@@ -544,8 +218,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@tootallnate/quickjs-emscripten@0.23.0': {}
-
   '@types/node@22.12.0':
     dependencies:
       undici-types: 6.20.0
@@ -556,426 +228,125 @@ snapshots:
     dependencies:
       '@types/node': 22.12.0
 
-  '@types/yauzl@2.10.3':
+  boolbase@1.0.0: {}
+
+  cheerio-select@2.1.0:
     dependencies:
-      '@types/node': 22.12.0
-    optional: true
+      boolbase: 1.0.0
+      css-select: 5.1.0
+      css-what: 6.1.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
 
-  agent-base@7.1.3: {}
-
-  ansi-regex@5.0.1: {}
-
-  ansi-styles@4.3.0:
+  cheerio@1.1.0:
     dependencies:
-      color-convert: 2.0.1
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.0.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.10.0
+      whatwg-mimetype: 4.0.0
 
-  argparse@2.0.1: {}
-
-  ast-types@0.13.4:
+  css-select@5.1.0:
     dependencies:
-      tslib: 2.8.1
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
 
-  b4a@1.6.7: {}
+  css-what@6.1.0: {}
 
-  bare-events@2.5.4:
-    optional: true
-
-  bare-fs@4.0.1:
+  dom-serializer@2.0.0:
     dependencies:
-      bare-events: 2.5.4
-      bare-path: 3.0.0
-      bare-stream: 2.6.4(bare-events@2.5.4)
-    transitivePeerDependencies:
-      - bare-buffer
-    optional: true
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
 
-  bare-os@3.4.0:
-    optional: true
+  domelementtype@2.3.0: {}
 
-  bare-path@3.0.0:
+  domhandler@5.0.3:
     dependencies:
-      bare-os: 3.4.0
-    optional: true
+      domelementtype: 2.3.0
 
-  bare-stream@2.6.4(bare-events@2.5.4):
+  domutils@3.2.2:
     dependencies:
-      streamx: 2.22.0
-    optionalDependencies:
-      bare-events: 2.5.4
-    optional: true
-
-  base64-js@1.5.1: {}
-
-  basic-ftp@5.0.5: {}
-
-  buffer-crc32@0.2.13: {}
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
-  callsites@3.1.0: {}
-
-  chromium-bidi@1.1.0(devtools-protocol@0.0.1380148):
-    dependencies:
-      devtools-protocol: 0.0.1380148
-      mitt: 3.0.1
-      zod: 3.24.1
-
-  cliui@8.0.1:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
-
-  cosmiconfig@9.0.0(typescript@5.7.3):
-    dependencies:
-      env-paths: 2.2.1
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      parse-json: 5.2.0
-    optionalDependencies:
-      typescript: 5.7.3
-
-  data-uri-to-buffer@6.0.2: {}
-
-  debug@4.4.0:
-    dependencies:
-      ms: 2.1.3
-
-  degenerator@5.0.1:
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 2.1.0
-      esprima: 4.0.1
-
-  devtools-protocol@0.0.1380148: {}
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dotenv@16.4.7: {}
 
-  emoji-regex@8.0.0: {}
-
-  end-of-stream@1.4.4:
+  encoding-sniffer@0.2.1:
     dependencies:
-      once: 1.4.0
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
 
-  env-paths@2.2.1: {}
+  entities@4.5.0: {}
 
-  error-ex@1.3.2:
+  entities@6.0.1: {}
+
+  htmlparser2@10.0.0:
     dependencies:
-      is-arrayish: 0.2.1
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 6.0.1
 
-  escalade@3.2.0: {}
-
-  escodegen@2.1.0:
+  iconv-lite@0.6.3:
     dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
+      safer-buffer: 2.1.2
 
-  esprima@4.0.1: {}
-
-  estraverse@5.3.0: {}
-
-  esutils@2.0.3: {}
-
-  extract-zip@2.0.1:
+  nth-check@2.1.1:
     dependencies:
-      debug: 4.4.0
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
-  fast-fifo@1.3.2: {}
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
-
-  get-caller-file@2.0.5: {}
-
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.2
-
-  get-uri@6.0.4:
-    dependencies:
-      basic-ftp: 5.0.5
-      data-uri-to-buffer: 6.0.2
-      debug: 4.4.0
-    transitivePeerDependencies:
-      - supports-color
-
-  http-proxy-agent@7.0.2:
-    dependencies:
-      agent-base: 7.1.3
-      debug: 4.4.0
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.3
-      debug: 4.4.0
-    transitivePeerDependencies:
-      - supports-color
-
-  ieee754@1.2.1: {}
-
-  import-fresh@3.3.0:
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
-
-  ip-address@9.0.5:
-    dependencies:
-      jsbn: 1.1.0
-      sprintf-js: 1.1.3
-
-  is-arrayish@0.2.1: {}
-
-  is-fullwidth-code-point@3.0.0: {}
-
-  js-tokens@4.0.0: {}
-
-  js-yaml@4.1.0:
-    dependencies:
-      argparse: 2.0.1
-
-  jsbn@1.1.0: {}
-
-  json-parse-even-better-errors@2.3.1: {}
-
-  lines-and-columns@1.2.4: {}
-
-  lru-cache@7.18.3: {}
-
-  mitt@3.0.1: {}
-
-  ms@2.1.3: {}
-
-  netmask@2.0.2: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
+      boolbase: 1.0.0
 
   p-limit@6.2.0:
     dependencies:
       yocto-queue: 1.1.1
 
-  pac-proxy-agent@7.1.0:
+  parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
-      '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.3
-      debug: 4.4.0
-      get-uri: 6.0.4
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
+      domhandler: 5.0.3
+      parse5: 7.3.0
 
-  pac-resolver@7.0.1:
+  parse5-parser-stream@7.1.2:
     dependencies:
-      degenerator: 5.0.1
-      netmask: 2.0.2
+      parse5: 7.3.0
 
-  parent-module@1.0.1:
+  parse5@7.3.0:
     dependencies:
-      callsites: 3.1.0
+      entities: 6.0.1
 
-  parse-json@5.2.0:
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      error-ex: 1.3.2
-      json-parse-even-better-errors: 2.3.1
-      lines-and-columns: 1.2.4
-
-  pend@1.2.0: {}
-
-  picocolors@1.1.1: {}
-
-  progress@2.0.3: {}
-
-  proxy-agent@6.5.0:
-    dependencies:
-      agent-base: 7.1.3
-      debug: 4.4.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      lru-cache: 7.18.3
-      pac-proxy-agent: 7.1.0
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  proxy-from-env@1.1.0: {}
-
-  pump@3.0.2:
-    dependencies:
-      end-of-stream: 1.4.4
-      once: 1.4.0
-
-  puppeteer-core@24.1.1:
-    dependencies:
-      '@puppeteer/browsers': 2.7.0
-      chromium-bidi: 1.1.0(devtools-protocol@0.0.1380148)
-      debug: 4.4.0
-      devtools-protocol: 0.0.1380148
-      typed-query-selector: 2.12.0
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bare-buffer
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  puppeteer@24.1.1(typescript@5.7.3):
-    dependencies:
-      '@puppeteer/browsers': 2.7.0
-      chromium-bidi: 1.1.0(devtools-protocol@0.0.1380148)
-      cosmiconfig: 9.0.0(typescript@5.7.3)
-      devtools-protocol: 0.0.1380148
-      puppeteer-core: 24.1.1
-      typed-query-selector: 2.12.0
-    transitivePeerDependencies:
-      - bare-buffer
-      - bufferutil
-      - supports-color
-      - typescript
-      - utf-8-validate
-
-  require-directory@2.1.1: {}
-
-  resolve-from@4.0.0: {}
-
-  semver@7.7.0: {}
-
-  smart-buffer@4.2.0: {}
-
-  socks-proxy-agent@8.0.5:
-    dependencies:
-      agent-base: 7.1.3
-      debug: 4.4.0
-      socks: 2.8.3
-    transitivePeerDependencies:
-      - supports-color
-
-  socks@2.8.3:
-    dependencies:
-      ip-address: 9.0.5
-      smart-buffer: 4.2.0
-
-  source-map@0.6.1:
-    optional: true
-
-  sprintf-js@1.1.3: {}
-
-  streamx@2.22.0:
-    dependencies:
-      fast-fifo: 1.3.2
-      text-decoder: 1.2.3
-    optionalDependencies:
-      bare-events: 2.5.4
-
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-
-  tar-fs@3.0.8:
-    dependencies:
-      pump: 3.0.2
-      tar-stream: 3.1.7
-    optionalDependencies:
-      bare-fs: 4.0.1
-      bare-path: 3.0.0
-    transitivePeerDependencies:
-      - bare-buffer
-
-  tar-stream@3.1.7:
-    dependencies:
-      b4a: 1.6.7
-      fast-fifo: 1.3.2
-      streamx: 2.22.0
-
-  text-decoder@1.2.3:
-    dependencies:
-      b4a: 1.6.7
-
-  through@2.3.8: {}
+  safer-buffer@2.1.2: {}
 
   tr46@0.0.3: {}
 
-  tslib@2.8.1: {}
-
-  typed-query-selector@2.12.0: {}
-
   typescript@5.7.3: {}
-
-  unbzip2-stream@1.4.3:
-    dependencies:
-      buffer: 5.7.1
-      through: 2.3.8
 
   undici-types@6.20.0: {}
 
+  undici@7.10.0: {}
+
   webidl-conversions@3.0.1: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  wrappy@1.0.2: {}
-
   ws@8.18.0: {}
 
-  y18n@5.0.8: {}
-
-  yargs-parser@21.1.1: {}
-
-  yargs@17.7.2:
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
-
   yocto-queue@1.1.1: {}
-
-  zod@3.24.1: {}

--- a/run-performance-test.sh
+++ b/run-performance-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "🚀 Starting Concurrency Performance Test"
+echo "This will test different concurrency values to find optimal settings"
+echo "Expected runtime: 5-10 minutes"
+echo ""
+
+# Build the TypeScript
+echo "📦 Building TypeScript..."
+pnpm build
+
+# Run the performance test
+echo "🧪 Running performance tests..."
+node dist/performance-test.js
+
+echo ""
+echo "✅ Performance test complete!"
+echo "Check the performance-test-results/ directory for detailed results"

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,6 +288,13 @@ const scrapeMenuData = async (url: string) => {
 
     const $ = cheerio.load(html);
 
+    // Extract menu date
+    const menuDateElement = $("div.shortmenutitle").text();
+    const menuDateMatch = menuDateElement.match(/Menus for (.+)/);
+    const menuDate = menuDateMatch
+      ? new Date(menuDateMatch[1].trim()).toISOString().slice(0, 10)
+      : null;
+
     // Find menu links
     const menuLinks: string[] = [];
     $('a[href*="longmenu.aspx"]').each((_, element) => {
@@ -412,6 +419,7 @@ const scrapeMenuData = async (url: string) => {
 
     return {
       locationName,
+      date: menuDate,
       menus: filteredMenus,
     };
   } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { join } from "path";
 import pLimit from "p-limit";
 import { mkdirSync, existsSync } from "fs";
 import { supabase } from "./supabase";
+import { config as dotenvConfig } from "dotenv";
+dotenvConfig();
 
 interface AllergenInfo {
   beef: boolean;
@@ -66,7 +68,7 @@ const LINKS = [
 const DATA_DIR = join(__dirname, "..", "data");
 const NUTRITION_CONCURRENCY = 50;
 const MENU_CONCURRENCY = 7;
-const ENABLE_SUPABASE = false;
+const ENABLE_SUPABASE = process.env.ENABLE_SUPABASE === "true";
 
 if (!existsSync(DATA_DIR)) {
   mkdirSync(DATA_DIR, { recursive: true });

--- a/src/performance-test.ts
+++ b/src/performance-test.ts
@@ -1,0 +1,590 @@
+import * as cheerio from "cheerio";
+import { writeFile } from "fs/promises";
+import { join } from "path";
+import pLimit from "p-limit";
+import { mkdirSync, existsSync } from "fs";
+
+interface AllergenInfo {
+  beef: boolean;
+  egg: boolean;
+  fish: boolean;
+  milk: boolean;
+  peanuts: boolean;
+  pork: boolean;
+  shellfish: boolean;
+  soy: boolean;
+  tree_nuts: boolean;
+  wheat: boolean;
+  sesame_seeds: boolean;
+  vegan: boolean;
+  vegetarian: boolean;
+  halal: boolean;
+}
+
+interface Section {
+  categoryName: string;
+  foods: Food[];
+}
+
+interface Food {
+  name: string;
+  link: string;
+  allergens: AllergenInfo;
+  nutrition?: Nutrition;
+}
+
+interface Nutrition {
+  servingSize: string;
+  calories: number;
+  totalFat: string;
+  saturatedFat: string;
+  transFat: string;
+  cholesterol: string;
+  totalCarbohydrates: string;
+  dietaryFiber: string;
+  totalSugars: string;
+  protein: string;
+  vitaminD: string;
+  calcium: string;
+  iron: string;
+  potassium: string;
+  sodium: string;
+  ingredients?: string;
+}
+
+interface TestResult {
+  nutritionConcurrency: number;
+  menuConcurrency: number;
+  duration: number;
+  totalItems: number;
+  successRate: number;
+  itemsPerSecond: number;
+  errors: number;
+}
+
+// Test configurations to try
+const TEST_CONFIGS = [
+  { nutrition: 20, menu: 5 },
+  { nutrition: 30, menu: 6 },
+  { nutrition: 40, menu: 7 },
+  { nutrition: 50, menu: 7 },
+  { nutrition: 60, menu: 8 },
+  { nutrition: 70, menu: 8 },
+  { nutrition: 80, menu: 9 },
+  { nutrition: 100, menu: 10 },
+];
+
+const LINKS = [
+  "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=12&locationName=J2+Dining&naFlag=1",
+  "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=12(a)&locationName=JCL+Dining&naFlag=1",
+  "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=03&locationName=Kins+Dining&naFlag=1",
+  "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=05&locationName=Jester+City+Market&naFlag=1",
+  "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=26&locationName=Jesta'+Pizza&naFlag=1",
+  "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=19&locationName=Littlefield+Patio+Cafe&naFlag=1",
+  "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=08&locationName=Cypress+Bend+Cafe+&naFlag=1",
+];
+
+const DATA_DIR = join(__dirname, "..", "performance-test-results");
+
+if (!existsSync(DATA_DIR)) {
+  mkdirSync(DATA_DIR, { recursive: true });
+}
+
+let errorCount = 0;
+
+// Fetch HTML content with error handling and retries
+const fetchHtml = async (url: string, retries = 3): Promise<string | null> => {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const response = await fetch(url, {
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+        },
+        signal: AbortSignal.timeout(15000),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      return await response.text();
+    } catch (error) {
+      if (i === 0) {
+        errorCount++;
+      }
+      if (i === retries - 1) return null;
+      await new Promise((resolve) => setTimeout(resolve, 1000 * (i + 1)));
+    }
+  }
+  return null;
+};
+
+const scrapeNutritionInfo = async (
+  url: string,
+  nutritionConcurrency: number
+): Promise<Nutrition | null> => {
+  try {
+    const html = await fetchHtml(url);
+    if (!html) return null;
+
+    const $ = cheerio.load(html);
+
+    const getNutrient = (label: string) => {
+      const elements = $(".nutfactstopnutrient");
+      let result = null;
+
+      elements.each((_, element) => {
+        const text = $(element).text();
+        if (text.includes(label)) {
+          const match = text.match(/([\d.]+)\s*([a-zA-Zμ]+)/);
+          if (match) {
+            result = `${match[1]}${match[2]}`;
+            return false;
+          }
+        }
+      });
+
+      return result;
+    };
+
+    const servingSizeElements = $(".nutfactsservsize");
+    const servingSize =
+      servingSizeElements.length > 1
+        ? $(servingSizeElements[1]).text().trim()
+        : "";
+
+    const caloriesText = $(".nutfactscaloriesval").text().trim();
+    const calories = parseFloat(caloriesText) || 0;
+
+    const ingredients = $(".labelingredientsvalue").text().trim() || undefined;
+
+    return {
+      servingSize,
+      calories,
+      totalFat: getNutrient("Total Fat") || "0g",
+      saturatedFat: getNutrient("Saturated Fat") || "0g",
+      transFat: getNutrient("Trans Fat") || "0g",
+      cholesterol: getNutrient("Cholesterol") || "0mg",
+      sodium: getNutrient("Sodium") || "0mg",
+      totalCarbohydrates: getNutrient("Total Carbohydrate") || "0g",
+      dietaryFiber: getNutrient("Dietary Fiber") || "0g",
+      totalSugars: getNutrient("Total Sugars") || "0g",
+      protein: getNutrient("Protein") || "0g",
+      vitaminD: getNutrient("Vitamin D") || "0mcg",
+      calcium: getNutrient("Calcium") || "0mg",
+      iron: getNutrient("Iron") || "0mg",
+      potassium: getNutrient("Potassium") || "0mg",
+      ingredients,
+    };
+  } catch (error) {
+    errorCount++;
+    return null;
+  }
+};
+
+const parseMenuStructure = ($: cheerio.CheerioAPI): Section[] => {
+  try {
+    const sectionMap = new Map<string, Section>();
+    let currentSection: Section | null = null;
+
+    $("tbody tr").each((_, row) => {
+      const $row = $(row);
+      const categoryHeader = $row.find(".longmenucolmenucat");
+
+      if (categoryHeader.length > 0) {
+        const categoryName =
+          categoryHeader
+            .text()
+            .replace(/^--\s*|[\s-]*$/g, "")
+            .trim() || "Uncategorized";
+
+        currentSection = sectionMap.get(categoryName) || {
+          categoryName,
+          foods: [],
+        };
+        sectionMap.set(categoryName, currentSection);
+      } else if (currentSection) {
+        const foodLink = $row.find(".longmenucoldispname a");
+        const foodCheckBox = $row.find(
+          '.longmenucoldispname input[type="checkbox"]'
+        );
+
+        if (foodLink.length > 0 && foodCheckBox.length > 0) {
+          const foodName = foodLink.text().trim();
+          if (!foodName) return;
+
+          const allergenMap = new Map<string, boolean>([
+            ["beef", false],
+            ["egg", false],
+            ["fish", false],
+            ["milk", false],
+            ["peanuts", false],
+            ["pork", false],
+            ["shellfish", false],
+            ["soy", false],
+            ["tree_nuts", false],
+            ["wheat", false],
+            ["sesame_seeds", false],
+            ["vegan", false],
+            ["vegetarian", false],
+            ["halal", false],
+          ]);
+
+          const allergenIcons = $row.find("img");
+          allergenIcons.each((_, img) => {
+            const imgSrc = $(img).attr("src");
+            if (!imgSrc) return;
+
+            const filename = imgSrc
+              .substring(imgSrc.lastIndexOf("/") + 1)
+              .replace(".png", "")
+              .toLowerCase()
+              .replace(/ /g, "_");
+
+            const allergenKeyMap: { [key: string]: keyof AllergenInfo } = {
+              beef: "beef",
+              eggs: "egg",
+              egg: "egg",
+              fish: "fish",
+              milk: "milk",
+              peanuts: "peanuts",
+              pork: "pork",
+              shellfish: "shellfish",
+              soy: "soy",
+              tree_nuts: "tree_nuts",
+              wheat: "wheat",
+              sesame: "sesame_seeds",
+              vegan: "vegan",
+              veggie: "vegetarian",
+            };
+
+            const allergenKey = allergenKeyMap[filename];
+            if (allergenKey && allergenMap.has(allergenKey)) {
+              allergenMap.set(allergenKey, true);
+            }
+          });
+
+          const allergens = Object.fromEntries(
+            allergenMap
+          ) as unknown as AllergenInfo;
+
+          const existingIndex = currentSection.foods.findIndex(
+            (f) => f.name === foodName
+          );
+
+          if (existingIndex === -1) {
+            const href = foodLink.attr("href");
+            const fullLink = href?.startsWith("http")
+              ? href
+              : `https://hf-foodpro.austin.utexas.edu/foodpro/${href}`;
+
+            currentSection.foods.push({
+              name: foodName,
+              link: fullLink,
+              allergens,
+            });
+          }
+        }
+      }
+    });
+
+    return Array.from(sectionMap.values()).filter(
+      (section) => section.foods.length > 0
+    );
+  } catch (error) {
+    errorCount++;
+    return [];
+  }
+};
+
+const scrapeMenuData = async (
+  url: string,
+  nutritionConcurrency: number,
+  menuConcurrency: number
+) => {
+  try {
+    const html = await fetchHtml(url);
+    if (!html) return null;
+
+    const $ = cheerio.load(html);
+
+    const menuLinks: string[] = [];
+    $('a[href*="longmenu.aspx"]').each((_, element) => {
+      const href = $(element).attr("href");
+      if (href) {
+        const fullLink = href.startsWith("http")
+          ? href
+          : `https://hf-foodpro.austin.utexas.edu/foodpro/${href}`;
+        menuLinks.push(fullLink);
+      }
+    });
+
+    const menuLimit = pLimit(3);
+    const menus = await Promise.all(
+      menuLinks.map((link) =>
+        menuLimit(async () => {
+          try {
+            const menuHtml = await fetchHtml(link);
+            if (!menuHtml) return null;
+
+            const menu$ = cheerio.load(menuHtml);
+
+            const categoryElement = menu$("a:has(div.longmenugridheader)");
+            const categoryText = categoryElement.text();
+            const category =
+              categoryText.split("Menu")[0].replace(/ /g, "").trim() ||
+              "Unknown";
+
+            const baseMenu = parseMenuStructure(menu$);
+
+            if (baseMenu.length === 0) {
+              return null;
+            }
+
+            const nutritionLimit = pLimit(nutritionConcurrency);
+            const foodsWithNutrition = await Promise.all(
+              baseMenu.flatMap((section) =>
+                section.foods.map(async (food) => {
+                  if (!food.link) return food;
+
+                  const nutrition = await nutritionLimit(() =>
+                    scrapeNutritionInfo(food.link, nutritionConcurrency)
+                  );
+
+                  return { ...food, nutrition };
+                })
+              )
+            );
+
+            const enhancedMenu = baseMenu.map((section) => {
+              const seenFoodNames = new Set();
+              const uniqueFoods = section.foods
+                .map((food) => {
+                  const foodWithNutrition = foodsWithNutrition.find(
+                    (f) => f.name === food.name
+                  );
+                  return foodWithNutrition || food;
+                })
+                .filter((food) => {
+                  if (seenFoodNames.has(food.name)) {
+                    return false;
+                  }
+                  seenFoodNames.add(food.name);
+                  return true;
+                });
+
+              return {
+                ...section,
+                foods: uniqueFoods,
+              };
+            });
+
+            const finalMenu = enhancedMenu.filter(
+              (section) => section.foods.length > 0
+            );
+            if (finalMenu.length === 0) {
+              return null;
+            }
+
+            return { type: category, menuCategories: finalMenu };
+          } catch (error) {
+            errorCount++;
+            return null;
+          }
+        })
+      )
+    );
+
+    const urlObj = new URL(url);
+    const locationName =
+      urlObj.searchParams.get("locationName")?.trim() || "Unknown Location";
+    const filteredMenus = menus.filter((m) => m !== null);
+
+    return {
+      locationName,
+      menus: filteredMenus,
+    };
+  } catch (error) {
+    errorCount++;
+    return null;
+  }
+};
+
+const runPerformanceTest = async (
+  nutritionConcurrency: number,
+  menuConcurrency: number
+): Promise<TestResult> => {
+  console.log(
+    `\n🧪 Testing: Nutrition=${nutritionConcurrency}, Menu=${menuConcurrency}`
+  );
+
+  const startTime = Date.now();
+  errorCount = 0;
+
+  try {
+    const menuUrlsSet = new Set<string>(LINKS);
+    const scraperLimit = pLimit(menuConcurrency);
+
+    const rawData = await Promise.all(
+      Array.from(menuUrlsSet).map((url) =>
+        scraperLimit(() =>
+          scrapeMenuData(url, nutritionConcurrency, menuConcurrency)
+        )
+      )
+    );
+
+    const endTime = Date.now();
+    const duration = (endTime - startTime) / 1000;
+
+    const data = rawData.filter((item) => item !== null);
+    const totalItems = data.reduce(
+      (sum, location) =>
+        sum +
+        location.menus.reduce(
+          (menuSum, menu) =>
+            menuSum +
+            menu.menuCategories.reduce(
+              (catSum, category) => catSum + category.foods.length,
+              0
+            ),
+          0
+        ),
+      0
+    );
+
+    const itemsWithNutrition = data.reduce(
+      (sum, location) =>
+        sum +
+        location.menus.reduce(
+          (menuSum, menu) =>
+            menuSum +
+            menu.menuCategories.reduce(
+              (catSum, category) =>
+                catSum + category.foods.filter((food) => food.nutrition).length,
+              0
+            ),
+          0
+        ),
+      0
+    );
+
+    const successRate =
+      totalItems > 0 ? (itemsWithNutrition / totalItems) * 100 : 0;
+    const itemsPerSecond = totalItems / duration;
+
+    const result: TestResult = {
+      nutritionConcurrency,
+      menuConcurrency,
+      duration,
+      totalItems,
+      successRate,
+      itemsPerSecond,
+      errors: errorCount,
+    };
+
+    console.log(`   ⏱️  Duration: ${duration.toFixed(2)}s`);
+    console.log(`   📊 Items: ${totalItems} (${itemsPerSecond.toFixed(1)}/s)`);
+    console.log(`   ✅ Success Rate: ${successRate.toFixed(1)}%`);
+    console.log(`   ❌ Errors: ${errorCount}`);
+
+    return result;
+  } catch (error) {
+    console.error(`   💥 Test failed:`, error);
+    return {
+      nutritionConcurrency,
+      menuConcurrency,
+      duration: -1,
+      totalItems: 0,
+      successRate: 0,
+      itemsPerSecond: 0,
+      errors: errorCount,
+    };
+  }
+};
+
+const main = async () => {
+  console.log("🚀 Starting Performance Test Suite");
+  console.log(
+    `📍 Testing ${LINKS.length} locations with ${TEST_CONFIGS.length} different configurations`
+  );
+  console.log("⚠️  This will take several minutes to complete...\n");
+
+  const results: TestResult[] = [];
+
+  for (const config of TEST_CONFIGS) {
+    const result = await runPerformanceTest(config.nutrition, config.menu);
+    results.push(result);
+
+    // Add a small delay between tests to avoid overwhelming the server
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+
+  // Analyze results
+  console.log("\n📈 PERFORMANCE TEST RESULTS");
+  console.log("=".repeat(80));
+  console.log(
+    "Nutrition | Menu | Duration | Items/s | Success% | Errors | Score"
+  );
+  console.log("-".repeat(80));
+
+  const validResults = results.filter(
+    (r) => r.duration > 0 && r.successRate > 90
+  );
+
+  results.forEach((result) => {
+    const score =
+      result.successRate > 90
+        ? result.itemsPerSecond *
+          (result.successRate / 100) *
+          (1 - result.errors / 100)
+        : 0;
+
+    console.log(
+      `${result.nutritionConcurrency.toString().padStart(9)} | ` +
+        `${result.menuConcurrency.toString().padStart(4)} | ` +
+        `${result.duration.toFixed(2).padStart(8)}s | ` +
+        `${result.itemsPerSecond.toFixed(1).padStart(7)} | ` +
+        `${result.successRate.toFixed(1).padStart(8)} | ` +
+        `${result.errors.toString().padStart(6)} | ` +
+        `${score.toFixed(2).padStart(5)}`
+    );
+  });
+
+  // Find optimal configuration
+  if (validResults.length > 0) {
+    const optimal = validResults.reduce((best, current) => {
+      const bestScore =
+        best.itemsPerSecond *
+        (best.successRate / 100) *
+        (1 - best.errors / 100);
+      const currentScore =
+        current.itemsPerSecond *
+        (current.successRate / 100) *
+        (1 - current.errors / 100);
+      return currentScore > bestScore ? current : best;
+    });
+
+    console.log("\n🏆 OPTIMAL CONFIGURATION:");
+    console.log(`   Nutrition Concurrency: ${optimal.nutritionConcurrency}`);
+    console.log(`   Menu Concurrency: ${optimal.menuConcurrency}`);
+    console.log(
+      `   Performance: ${optimal.itemsPerSecond.toFixed(1)} items/second`
+    );
+    console.log(`   Success Rate: ${optimal.successRate.toFixed(1)}%`);
+    console.log(`   Duration: ${optimal.duration.toFixed(2)} seconds`);
+  } else {
+    console.log(
+      "\n❌ No valid configurations found (all had <90% success rate)"
+    );
+  }
+
+  // Save detailed results
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const fileName = `performance_test_${timestamp}.json`;
+  const filePath = join(DATA_DIR, fileName);
+  await writeFile(filePath, JSON.stringify(results, null, 2), "utf-8");
+  console.log(`\n💾 Detailed results saved to ${filePath}`);
+};
+
+main().catch(console.error);

--- a/src/performance-test.ts
+++ b/src/performance-test.ts
@@ -60,6 +60,7 @@ interface TestResult {
   successRate: number;
   itemsPerSecond: number;
   errors: number;
+  memoryUsage: number;
 }
 
 // Test configurations to try
@@ -83,6 +84,20 @@ const LINKS = [
   "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=19&locationName=Littlefield+Patio+Cafe&naFlag=1",
   "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=08&locationName=Cypress+Bend+Cafe+&naFlag=1",
 ];
+
+// const LINKS = [
+//   "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=12&locationName=J2+Dining&naFlag=1&WeeksMenus=This+Week%27s+Menus&myaction=read&dtdate=6%2f20%2f2025",
+//   "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=12&locationName=J2+Dining&naFlag=1&WeeksMenus=This+Week%27s+Menus&myaction=read&dtdate=6%2f21%2f2025",
+//   "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=12&locationName=J2+Dining&naFlag=1&WeeksMenus=This+Week%27s+Menus&myaction=read&dtdate=6%2f22%2f2025",
+//   "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=12&locationName=J2+Dining&naFlag=1&WeeksMenus=This+Week%27s+Menus&myaction=read&dtdate=6%2f23%2f2025",
+//   "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=12&locationName=J2+Dining&naFlag=1&WeeksMenus=This+Week%27s+Menus&myaction=read&dtdate=6%2f24%2f2025",
+//   "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=12&locationName=J2+Dining&naFlag=1&WeeksMenus=This+Week%27s+Menus&myaction=read&dtdate=6%2f25%2f2025",
+//   "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=12&locationName=J2+Dining&naFlag=1&WeeksMenus=This+Week%27s+Menus&myaction=read&dtdate=6%2f26%2f2025",
+//   "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=12&locationName=J2+Dining&naFlag=1&WeeksMenus=This+Week%27s+Menus&myaction=read&dtdate=6%2f27%2f2025",
+//   "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=12&locationName=J2+Dining&naFlag=1&WeeksMenus=This+Week%27s+Menus&myaction=read&dtdate=6%2f28%2f2025",
+//   "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=12&locationName=J2+Dining&naFlag=1&WeeksMenus=This+Week%27s+Menus&myaction=read&dtdate=6%2f29%2f2025",
+//   "https://hf-foodpro.austin.utexas.edu/foodpro/shortmenu.aspx?sName=University+Housing+and+Dining&locationNum=12&locationName=J2+Dining&naFlag=1&WeeksMenus=This+Week%27s+Menus&myaction=read&dtdate=6%2f30%2f2025",
+// ];
 
 const DATA_DIR = join(__dirname, "..", "performance-test-results");
 
@@ -420,6 +435,7 @@ const runPerformanceTest = async (
   );
 
   const startTime = Date.now();
+  const startMemory = process.memoryUsage().heapUsed;
   errorCount = 0;
 
   try {
@@ -435,7 +451,9 @@ const runPerformanceTest = async (
     );
 
     const endTime = Date.now();
+    const endMemory = process.memoryUsage().heapUsed;
     const duration = (endTime - startTime) / 1000;
+    const memoryUsage = (endMemory - startMemory) / 1024 / 1024; // Convert to MB
 
     const data = rawData.filter((item) => item !== null);
     const totalItems = data.reduce(
@@ -481,12 +499,14 @@ const runPerformanceTest = async (
       successRate,
       itemsPerSecond,
       errors: errorCount,
+      memoryUsage,
     };
 
     console.log(`   ⏱️  Duration: ${duration.toFixed(2)}s`);
     console.log(`   📊 Items: ${totalItems} (${itemsPerSecond.toFixed(1)}/s)`);
     console.log(`   ✅ Success Rate: ${successRate.toFixed(1)}%`);
     console.log(`   ❌ Errors: ${errorCount}`);
+    console.log(`   🧠 Memory Usage: ${memoryUsage.toFixed(2)} MB`);
 
     return result;
   } catch (error) {
@@ -499,6 +519,7 @@ const runPerformanceTest = async (
       successRate: 0,
       itemsPerSecond: 0,
       errors: errorCount,
+      memoryUsage: 0,
     };
   }
 };

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -2,7 +2,7 @@ import { config } from "dotenv";
 config();
 
 import { createClient } from "@supabase/supabase-js";
-import { Database } from "./types/supabase-types";
+import { Database } from "./types/database.types";
 
 const supabaseUrl = process.env.SUPABASE_URL || "";
 const supabaseKey = process.env.SUPABASE_KEY || "";

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -155,6 +155,7 @@ export type Database = {
           colloquial_name: string | null
           created_at: string | null
           description: string
+          force_close: boolean
           google_maps_link: string
           id: string
           image: string | null
@@ -171,6 +172,7 @@ export type Database = {
           colloquial_name?: string | null
           created_at?: string | null
           description?: string
+          force_close?: boolean
           google_maps_link?: string
           id?: string
           image?: string | null
@@ -187,6 +189,7 @@ export type Database = {
           colloquial_name?: string | null
           created_at?: string | null
           description?: string
+          force_close?: boolean
           google_maps_link?: string
           id?: string
           image?: string | null
@@ -210,18 +213,21 @@ export type Database = {
       location_type: {
         Row: {
           created_at: string | null
+          display_order: number
           id: string
           name: string
           updated_at: string | null
         }
         Insert: {
           created_at?: string | null
+          display_order?: number
           id?: string
           name: string
           updated_at?: string | null
         }
         Update: {
           created_at?: string | null
+          display_order?: number
           id?: string
           name?: string
           updated_at?: string | null

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1,0 +1,492 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          operationName?: string
+          query?: string
+          variables?: Json
+          extensions?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  public: {
+    Tables: {
+      allergens: {
+        Row: {
+          beef: boolean | null
+          egg: boolean | null
+          fish: boolean | null
+          food_item_id: number | null
+          halal: boolean | null
+          id: number
+          milk: boolean | null
+          peanuts: boolean | null
+          pork: boolean | null
+          sesame_seeds: boolean | null
+          shellfish: boolean | null
+          soy: boolean | null
+          tree_nuts: boolean | null
+          vegan: boolean | null
+          vegetarian: boolean | null
+          wheat: boolean | null
+        }
+        Insert: {
+          beef?: boolean | null
+          egg?: boolean | null
+          fish?: boolean | null
+          food_item_id?: number | null
+          halal?: boolean | null
+          id?: number
+          milk?: boolean | null
+          peanuts?: boolean | null
+          pork?: boolean | null
+          sesame_seeds?: boolean | null
+          shellfish?: boolean | null
+          soy?: boolean | null
+          tree_nuts?: boolean | null
+          vegan?: boolean | null
+          vegetarian?: boolean | null
+          wheat?: boolean | null
+        }
+        Update: {
+          beef?: boolean | null
+          egg?: boolean | null
+          fish?: boolean | null
+          food_item_id?: number | null
+          halal?: boolean | null
+          id?: number
+          milk?: boolean | null
+          peanuts?: boolean | null
+          pork?: boolean | null
+          sesame_seeds?: boolean | null
+          shellfish?: boolean | null
+          soy?: boolean | null
+          tree_nuts?: boolean | null
+          vegan?: boolean | null
+          vegetarian?: boolean | null
+          wheat?: boolean | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "allergens_food_item_id_fkey"
+            columns: ["food_item_id"]
+            isOneToOne: false
+            referencedRelation: "food_item"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      food_item: {
+        Row: {
+          allergens_id: number | null
+          id: number
+          link: string | null
+          menu_category_id: number | null
+          name: string | null
+          nutrition_id: number | null
+        }
+        Insert: {
+          allergens_id?: number | null
+          id?: number
+          link?: string | null
+          menu_category_id?: number | null
+          name?: string | null
+          nutrition_id?: number | null
+        }
+        Update: {
+          allergens_id?: number | null
+          id?: number
+          link?: string | null
+          menu_category_id?: number | null
+          name?: string | null
+          nutrition_id?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "food_item_allergens_id_fkey"
+            columns: ["allergens_id"]
+            isOneToOne: false
+            referencedRelation: "allergens"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "food_item_menu_category_id_fkey"
+            columns: ["menu_category_id"]
+            isOneToOne: false
+            referencedRelation: "menu_category"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "food_item_nutrition_id_fkey"
+            columns: ["nutrition_id"]
+            isOneToOne: false
+            referencedRelation: "nutrition"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      location: {
+        Row: {
+          address: string
+          apple_maps_link: string
+          colloquial_name: string | null
+          created_at: string | null
+          description: string
+          google_maps_link: string
+          id: string
+          image: string | null
+          meal_times: Json[]
+          methods_of_payment: Database["public"]["Enums"]["payment_method"][]
+          name: string | null
+          regular_service_hours: Json
+          type_id: string
+          updated_at: string | null
+        }
+        Insert: {
+          address?: string
+          apple_maps_link?: string
+          colloquial_name?: string | null
+          created_at?: string | null
+          description?: string
+          google_maps_link?: string
+          id?: string
+          image?: string | null
+          meal_times?: Json[]
+          methods_of_payment?: Database["public"]["Enums"]["payment_method"][]
+          name?: string | null
+          regular_service_hours?: Json
+          type_id: string
+          updated_at?: string | null
+        }
+        Update: {
+          address?: string
+          apple_maps_link?: string
+          colloquial_name?: string | null
+          created_at?: string | null
+          description?: string
+          google_maps_link?: string
+          id?: string
+          image?: string | null
+          meal_times?: Json[]
+          methods_of_payment?: Database["public"]["Enums"]["payment_method"][]
+          name?: string | null
+          regular_service_hours?: Json
+          type_id?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "location_type_id_fkey"
+            columns: ["type_id"]
+            isOneToOne: false
+            referencedRelation: "location_type"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      location_type: {
+        Row: {
+          created_at: string | null
+          id: string
+          name: string
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          name: string
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          name?: string
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      menu: {
+        Row: {
+          id: number
+          location_id: string | null
+          name: string | null
+        }
+        Insert: {
+          id?: number
+          location_id?: string | null
+          name?: string | null
+        }
+        Update: {
+          id?: number
+          location_id?: string | null
+          name?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "menu_location_id_fkey"
+            columns: ["location_id"]
+            isOneToOne: false
+            referencedRelation: "location"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      menu_category: {
+        Row: {
+          id: number
+          menu_id: number
+          title: string | null
+        }
+        Insert: {
+          id?: number
+          menu_id: number
+          title?: string | null
+        }
+        Update: {
+          id?: number
+          menu_id?: number
+          title?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "menu_category_menu_id_fkey"
+            columns: ["menu_id"]
+            isOneToOne: false
+            referencedRelation: "menu"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      nutrition: {
+        Row: {
+          calcium: string | null
+          calories: string | null
+          cholesterol: string | null
+          dietary_fiber: string | null
+          food_item_id: number | null
+          id: number
+          ingredients: string | null
+          iron: string | null
+          potassium: string | null
+          protein: string | null
+          saturated_fat: string | null
+          serving_size: string | null
+          sodium: string | null
+          total_carbohydrates: string | null
+          total_fat: string | null
+          total_sugars: string | null
+          trans_fat: string | null
+          vitamin_d: string | null
+        }
+        Insert: {
+          calcium?: string | null
+          calories?: string | null
+          cholesterol?: string | null
+          dietary_fiber?: string | null
+          food_item_id?: number | null
+          id?: number
+          ingredients?: string | null
+          iron?: string | null
+          potassium?: string | null
+          protein?: string | null
+          saturated_fat?: string | null
+          serving_size?: string | null
+          sodium?: string | null
+          total_carbohydrates?: string | null
+          total_fat?: string | null
+          total_sugars?: string | null
+          trans_fat?: string | null
+          vitamin_d?: string | null
+        }
+        Update: {
+          calcium?: string | null
+          calories?: string | null
+          cholesterol?: string | null
+          dietary_fiber?: string | null
+          food_item_id?: number | null
+          id?: number
+          ingredients?: string | null
+          iron?: string | null
+          potassium?: string | null
+          protein?: string | null
+          saturated_fat?: string | null
+          serving_size?: string | null
+          sodium?: string | null
+          total_carbohydrates?: string | null
+          total_fat?: string | null
+          total_sugars?: string | null
+          trans_fat?: string | null
+          vitamin_d?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "nutrition_food_item_id_fkey"
+            columns: ["food_item_id"]
+            isOneToOne: false
+            referencedRelation: "food_item"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      insert_location_and_menus: {
+        Args: { arg_data: Json }
+        Returns: boolean
+      }
+      insert_multiple_locations_and_menus: {
+        Args: { arg_data_array: Json[] }
+        Returns: boolean
+      }
+    }
+    Enums: {
+      payment_method: "Bevo Pay" | "Cash" | "Credit/Debit" | "Dine In Dollars"
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DefaultSchema = Database[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {
+      payment_method: ["Bevo Pay", "Cash", "Credit/Debit", "Dine In Dollars"],
+    },
+  },
+} as const
+


### PR DESCRIPTION
Revamped the web scraper to use Cheerio instead of Puppeteer, resulting in a ~14× speedup. This version remains backwards compatible with the current backend (as of 6/26/2025) and also supports the upcoming revamped backend described [here](https://github.com/Longhorn-Developers/UT-Dining/pull/76). Includes performance testing to benchmark and tune concurrency settings.